### PR TITLE
modify every _monitor_func will capture one packet into packets

### DIFF
--- a/katnip/monitors/network.py
+++ b/katnip/monitors/network.py
@@ -87,7 +87,7 @@ class NetworkMonitor(BaseMonitor):
         '''
         self.logger.debug('in _monitor_func')
         if self._sock:
-            packet = self._sock.recv(1600)
+            packet = self._sock.recv()
             if packet and (self._packets is not None):
                 self._packets.append(packet)
 


### PR DESCRIPTION
My environments is macOS 10.14.3 and python 3.7.2 . The NetworkMonitor will not capture packet and I find if recv(somenumber) will raise invalid arguments error in scapy.arch.bpf.supersocket.py line 296 in scapy version 2.4.2 . And if I modify recv() , it can work successfully.

test.py
```

if __name__ == '__main__':
    import time
    print('creating monitor')
    mon = NetworkMonitor('en0', '/Users/shaoshuai/SS', 'Dummy Monitor')
    print('calling mon.setup')
    mon.setup()
    print('calling mon.pre_test')
    mon.pre_test(1)
    print('calling time.sleep(5)')
    time.sleep(5)
    print('calling mon.post_test')
    mon.post_test()
    print('calling mon.teardown')
    mon.teardown()
    print('---- done ----')

```
Below picture is successful screenshot
![image](https://user-images.githubusercontent.com/11012329/56588305-aa5bcc80-6615-11e9-9e10-23dbeeb75b97.png)
